### PR TITLE
Change collision handling for performance

### DIFF
--- a/grasp_generation/scripts/eval_all_grasp_config_dicts.py
+++ b/grasp_generation/scripts/eval_all_grasp_config_dicts.py
@@ -26,6 +26,7 @@ class EvalAllGraspConfigDictsArgumentParser(Tap):
     output_evaled_grasp_config_dicts_path: pathlib.Path = pathlib.Path(
         "../data/evaled_grasp_config_dicts"
     )
+    max_grasps_per_batch: int = 1000
     randomize_order_seed: Optional[int] = None
 
 
@@ -98,6 +99,7 @@ def main(args: EvalAllGraspConfigDictsArgumentParser):
                 f"--input_grasp_config_dicts_path {args.input_grasp_config_dicts_path}",
                 f"--output_evaled_grasp_config_dicts_path {args.output_evaled_grasp_config_dicts_path}",
                 f"--object_code_and_scale_str {object_code_and_scale_str}",
+                f"--max_grasps_per_batch {args.max_grasps_per_batch}",
             ]
         )
         print(f"Running command: {command}")

--- a/grasp_generation/scripts/eval_all_grasp_config_dicts.py
+++ b/grasp_generation/scripts/eval_all_grasp_config_dicts.py
@@ -22,6 +22,7 @@ class EvalAllGraspConfigDictsArgumentParser(Tap):
     input_grasp_config_dicts_path: pathlib.Path = pathlib.Path(
         "../data/grasp_config_dicts"
     )
+    meshdata_root_path: pathlib.Path = pathlib.Path("../data/meshdata")
     output_evaled_grasp_config_dicts_path: pathlib.Path = pathlib.Path(
         "../data/evaled_grasp_config_dicts"
     )
@@ -40,9 +41,11 @@ def get_object_code_and_scale_strs_to_process(
     )
 
     # Compare input and output directories
-    existing_object_code_and_scale_strs = [
-        path.stem for path in args.output_evaled_grasp_config_dicts_path.iterdir()
-    ] if args.output_evaled_grasp_config_dicts_path.exists() else []
+    existing_object_code_and_scale_strs = (
+        [path.stem for path in args.output_evaled_grasp_config_dicts_path.iterdir()]
+        if args.output_evaled_grasp_config_dicts_path.exists()
+        else []
+    )
     print(
         f"Found {len(existing_object_code_and_scale_strs)} object codes in {args.output_evaled_grasp_config_dicts_path}"
     )
@@ -74,7 +77,9 @@ def main(args: EvalAllGraspConfigDictsArgumentParser):
 
     input_object_code_and_scale_strs = get_object_code_and_scale_strs_to_process(args)
     if args.randomize_order_seed is not None:
-        random.Random(args.randomize_order_seed).shuffle(input_object_code_and_scale_strs)
+        random.Random(args.randomize_order_seed).shuffle(
+            input_object_code_and_scale_strs
+        )
     print(f"Processing {len(input_object_code_and_scale_strs)} object codes")
     print(f"First 10 object codes: {input_object_code_and_scale_strs[:10]}")
 
@@ -89,6 +94,7 @@ def main(args: EvalAllGraspConfigDictsArgumentParser):
                 f"--hand_model_type {args.hand_model_type.name}",
                 f"--validation_type {args.validation_type.name}",
                 f"--gpu {args.gpu}",
+                f"--meshdata_root_path {args.meshdata_root_path}",
                 f"--input_grasp_config_dicts_path {args.input_grasp_config_dicts_path}",
                 f"--output_evaled_grasp_config_dicts_path {args.output_evaled_grasp_config_dicts_path}",
                 f"--object_code_and_scale_str {object_code_and_scale_str}",

--- a/grasp_generation/scripts/eval_grasp_config_dict.py
+++ b/grasp_generation/scripts/eval_grasp_config_dict.py
@@ -45,6 +45,7 @@ class EvalGraspConfigDictArgumentParser(Tap):
     input_grasp_config_dicts_path: pathlib.Path = pathlib.Path(
         "../data/grasp_config_dicts"
     )
+    max_grasps_per_batch: int = 1000
     object_code_and_scale_str: str = "core-bottle-2722bec1947151b86e22e2d2f64c8cef_0_10"
     output_evaled_grasp_config_dicts_path: pathlib.Path = pathlib.Path(
         "../data/evaled_grasp_config_dicts"


### PR DESCRIPTION
Some quick changes to `IsaacValidator` -- now pass different collision indices to actors in different envs during IG sim construction. This culls tons of collision checking for performance.

Also made some minor tweaks to the entrypoint scripts to pass up some low-level command line args I needed.

Handle a rare edge case where grasp directions were equal to zero (happens when hand points are exactly on object surface) by pointing the finger towards the origin. 