### PR TITLE
Performance improvements + batching for eval collision

### DIFF
--- a/grasp_generation/scripts/eval_all_grasp_config_dicts.py
+++ b/grasp_generation/scripts/eval_all_grasp_config_dicts.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import subprocess
 import random
 import os
@@ -19,14 +20,16 @@ class EvalAllGraspConfigDictsArgumentParser(Tap):
     hand_model_type: HandModelType = HandModelType.ALLEGRO_HAND
     validation_type: ValidationType = ValidationType.NO_GRAVITY_SHAKING
     gpu: int = 0
+    max_grasps_per_batch: int = 500
+    debug_index: Optional[int] = None
     input_grasp_config_dicts_path: pathlib.Path = pathlib.Path(
         "../data/grasp_config_dicts"
     )
+    use_gui: bool = False
     meshdata_root_path: pathlib.Path = pathlib.Path("../data/meshdata")
     output_evaled_grasp_config_dicts_path: pathlib.Path = pathlib.Path(
         "../data/evaled_grasp_config_dicts"
     )
-    max_grasps_per_batch: int = 1000
     randomize_order_seed: Optional[int] = None
 
 
@@ -102,6 +105,13 @@ def main(args: EvalAllGraspConfigDictsArgumentParser):
                 f"--max_grasps_per_batch {args.max_grasps_per_batch}",
             ]
         )
+
+        if args.debug_index is not None:
+            command += f" --debug_index {args.debug_index}"
+
+        if args.use_gui:
+            command += " --use_gui"
+
         print(f"Running command: {command}")
 
         try:

--- a/grasp_generation/utils/isaac_validator.py
+++ b/grasp_generation/utils/isaac_validator.py
@@ -318,6 +318,17 @@ class IsaacValidator:
         self.init_hand_poses.append(hand_pose)
         self.collision_idx = collision_idx
 
+        # 💀 HERE THAR BE MONSTERS 👹
+        # We hardcoded the collision filter for the hand to 2, but have no clue
+        # what this actually does. It was originally set to -1, but this
+        # would cause the collision buffer to overflow.
+
+        # Occasionally we get a warning like:
+        # "internal error : Contact buffer overflow detected, please increase its size"
+        # but it doesn't seem to affect the realism of the simulation.
+
+        # <3 preston and albert
+
         # Create hand
         hand_actor_handle = gym.create_actor(
             env,
@@ -325,7 +336,7 @@ class IsaacValidator:
             hand_pose,
             "hand",
             collision_idx,
-            1,
+            2,
         )
         self.hand_handles.append(hand_actor_handle)
 
@@ -715,6 +726,11 @@ class IsaacValidator:
         self.obj_link_idx_to_name_dicts = []
         self.hand_asset = None
         self.obj_asset = None
+
+        # Recreate hand asset in new sim.
+        self.hand_asset = gym.load_asset(
+            self.sim, self.hand_root, self.hand_file, self.hand_asset_options
+        )
 
     def destroy(self):
         gym.destroy_sim(self.sim)


### PR DESCRIPTION
Adds a small loop to batch grasp eval if the collision buffer is overflowing. Also adds some collision filtering that seems to improve performance (can fit 2500 grasps on the GPU at Caltech).