### PR TITLE
Testing simplified datagen pipeline

### DIFF
--- a/grasp_generation/scripts/generate_nerf_data_one_object_one_scale.py
+++ b/grasp_generation/scripts/generate_nerf_data_one_object_one_scale.py
@@ -23,6 +23,8 @@ class GenerateNerfDataOneObjectOneScaleArgumentParser(Tap):
     output_nerfdata_path: pathlib.Path = pathlib.Path("../data/nerfdata")
     object_code: str = "sem-Camera-7bff4fd4dc53de7496dece3f86cb5dd5"
     object_scale: float = 0.1
+    generate_seg: bool = False
+    generate_depth: bool = False
 
 
 def main(args: GenerateNerfDataOneObjectOneScaleArgumentParser):
@@ -31,10 +33,10 @@ def main(args: GenerateNerfDataOneObjectOneScaleArgumentParser):
 
     output_nerf_object_path = (
         args.output_nerfdata_path
-        / f"{args.object_code}_{args.object_scale:.2f}".replace(".", "_")
+        / f"{args.object_code}_{args.object_scale:.4f}".replace(".", "_")
     )
     if output_nerf_object_path.exists():
-        print(f"Skipping {args.object_code} at scale {args.object_scale:.2f}")
+        print(f"Skipping {args.object_code} at scale {args.object_scale:.4f}")
         return
 
     # Create sim
@@ -51,13 +53,14 @@ def main(args: GenerateNerfDataOneObjectOneScaleArgumentParser):
     sim.add_env_nerf_data_collection(
         obj_scale=args.object_scale,
     )
-    sim.save_images(folder=str(output_nerf_object_path))
-    sim.create_train_val_test_split(
-        folder=str(output_nerf_object_path), train_frac=0.8, val_frac=0.1
+    sim.save_images_lightweight(
+        folder=str(output_nerf_object_path),
+        generate_seg=args.generate_seg,
+        generate_depth=args.generate_depth,
     )
+    sim.create_no_split_data(folder=str(output_nerf_object_path))
     sim.reset_simulator()
     sim.destroy()
-
 
 if __name__ == "__main__":
     args = GenerateNerfDataOneObjectOneScaleArgumentParser().parse_args()

--- a/grasp_generation/scripts/generate_nerf_data_one_object_one_scale.py
+++ b/grasp_generation/scripts/generate_nerf_data_one_object_one_scale.py
@@ -53,8 +53,13 @@ def main(args: GenerateNerfDataOneObjectOneScaleArgumentParser):
     sim.add_env_nerf_data_collection(
         obj_scale=args.object_scale,
     )
+
+    # ORIGINAL SCALING STRATEGY:
+    # object scale = 0.1
+    # camera radius = 0.3
     sim.save_images_lightweight(
         folder=str(output_nerf_object_path),
+        obj_scale=args.object_scale,
         generate_seg=args.generate_seg,
         generate_depth=args.generate_depth,
     )

--- a/grasp_generation/utils/isaac_validator.py
+++ b/grasp_generation/utils/isaac_validator.py
@@ -884,6 +884,32 @@ class IsaacValidator:
         # Avoid segfault if run multiple times by destroying camera sensors
         self._destroy_cameras(self.envs[0])
 
+    def save_images_lightweight(
+        self,
+        folder: str,
+        overwrite: bool = False,
+        generate_seg: bool = False,
+        generate_depth: bool = False,
+    ) -> None:
+        assert len(self.envs) == 1
+        self._setup_cameras(self.envs[0])
+
+        gym.step_graphics(self.sim)
+        gym.render_all_camera_sensors(self.sim)
+        path = self._setup_save_dir(folder, overwrite)
+
+        for ii, camera_handle in enumerate(self.camera_handles):
+            self._save_single_image_lightweight(
+                path,
+                ii,
+                camera_handle,
+                generate_seg=generate_seg,
+                generate_depth=generate_depth,
+            )
+
+        # Avoid segfault if run multiple times by destroying camera sensors
+        self._destroy_cameras(self.envs[0])
+
     def _setup_cameras(self, env, num_cameras=750, radius=0.3):
         camera_props = gymapi.CameraProperties()
         camera_props.horizontal_fov = CAMERA_HORIZONTAL_FOV_DEG
@@ -1007,6 +1033,62 @@ class IsaacValidator:
             data = [*pos.tolist(), *quat.q[1:].tolist(), quat.q[0].tolist()]
             json.dump(data, f)
 
+    def _save_single_image_lightweight(
+        self,
+        path,
+        ii,
+        camera_handle,
+        generate_seg=False,
+        generate_depth=False,
+        numpy_depth=False,
+        debug=False,
+    ):
+        if debug:
+            print(f"saving camera {ii}")
+        env_idx = 0
+        env = self.envs[env_idx]
+
+        # COLOR IMAGE
+        # NEED THESE TEMPORARILY FOR transforms.json
+        color_image = gym.get_camera_image(
+            self.sim, env, camera_handle, gymapi.IMAGE_COLOR
+        )
+        color_image = color_image.reshape(CAMERA_IMG_HEIGHT, CAMERA_IMG_WIDTH, -1)
+        Image.fromarray(color_image).save(path / f"col_{ii}.png")
+
+        # SEGMENTATION IMAGE
+        if generate_seg:
+            segmentation_image = gym.get_camera_image(
+                self.sim, env, camera_handle, gymapi.IMAGE_SEGMENTATION
+            )
+            segmentation_image = segmentation_image == OBJ_SEGMENTATION_ID
+            segmentation_image = (
+                segmentation_image.reshape(CAMERA_IMG_HEIGHT, CAMERA_IMG_WIDTH) * 255
+            ).astype(np.uint8)
+            Image.fromarray(segmentation_image).convert("L").save(
+                path / f"seg_{ii}.png"
+            )
+
+        # DEPTH IMAGE
+        if generate_depth:
+            depth_image = gym.get_camera_image(
+                self.sim, env, camera_handle, gymapi.IMAGE_DEPTH
+            )
+            depth_image = -1000 * depth_image.reshape(
+                CAMERA_IMG_HEIGHT, CAMERA_IMG_WIDTH
+            )
+            if numpy_depth:
+                np.save(path / f"dep_{ii}.npy", depth_image)
+            else:
+                depth_image = (depth_image).astype(np.uint8)
+                Image.fromarray(depth_image).convert("L").save(path / f"dep_{ii}.png")
+
+        # NEED THESE TEMPORARILY FOR transforms.json
+        pos, quat = get_fixed_camera_transform(gym, self.sim, env, camera_handle)
+        with open(path / f"pos_xyz_quat_xyzw_{ii}.txt", "w+") as f:
+            data = [*pos.tolist(), *quat.q[1:].tolist(), quat.q[0].tolist()]
+            json.dump(data, f)
+
     def create_train_val_test_split(
         self, folder: str, train_frac: float, val_frac: float
     ) -> None:
@@ -1034,6 +1116,23 @@ class IsaacValidator:
         )
         self._create_one_split(split_name="val", split_range=val_range, folder=folder)
         self._create_one_split(split_name="test", split_range=test_range, folder=folder)
+
+    def create_no_split_data(self, folder: str) -> None:
+        # create the images folder and transforms.json
+        num_imgs = len(self.camera_handles)
+        print()
+        print(f"num_imgs = {num_imgs}")
+        print()
+        img_range = np.arange(num_imgs)
+        self._create_one_split(
+            split_name="images", split_range=img_range, folder=folder
+        )
+
+        # delete all the .txt files
+        directory = os.listdir(folder)
+        for item in directory:
+            if item.endswith(".txt"):
+                os.remove(os.path.join(directory, item))
 
     def _run_sanity_check_proj_matrices_all_same(self):
         proj_matrix = gym.get_camera_proj_matrix(


### PR DESCRIPTION
Updates the grasp generation script (for one scale) with the following changes:
1. No train/test/val split. All images are saved to a directory called `images`, and this change is also reflected in a single `transforms.json`.
2. All other outputs of this script are not generated except optionally segmentation/depth images (false by default), which you can generate by passing in args.
3. The scale of the images is saved up to 4 decimal places of precision in the file name.
4. scales the camera placement radius with the object scale. Original: 0.1 scale hardcoded with 0.3 camera radius. Now: `radius=3*scale`.