### PR TITLE
Add fetch_results and prepare_sim

### DIFF
--- a/grasp_generation/scripts/eval_grasp_config_dict.py
+++ b/grasp_generation/scripts/eval_grasp_config_dict.py
@@ -240,12 +240,12 @@ def main(args: EvalGraspConfigDictArgumentParser):
                 record=index in args.record_indices,
             )
         batch_successes = sim.run_sim()
-        successes.append(batch_successes)
+        successes.extend(batch_successes)
         sim.reset_simulator()
         pbar.set_description(f"mean_success = {np.mean(successes)}")
 
     # Aggregate results
-    successes = np.concatenate(successes, axis=0)
+    successes = np.array(successes)
     assert len(successes) == batch_size
     passed_simulation = np.array(successes)
 

--- a/grasp_generation/utils/isaac_validator.py
+++ b/grasp_generation/utils/isaac_validator.py
@@ -478,6 +478,8 @@ class IsaacValidator:
         return
 
     def run_sim(self):
+        gym.prepare_sim(self.sim)  # TODO: Check if this is needed?
+
         sim_step_idx = 0
         default_desc = "Simulating"
         pbar = tqdm(total=self.num_sim_steps, desc=default_desc, dynamic_ncols=True)
@@ -492,6 +494,7 @@ class IsaacValidator:
             # Step physics if not paused
             if not self.is_paused:
                 gym.simulate(self.sim)
+                gym.fetch_results(self.sim, True)  # TODO: Check if this slows things down
 
                 if self.camera_handles and sim_step_idx > 0:
                     gym.step_graphics(self.sim)


### PR DESCRIPTION
Changes:
* Add in `fetch_results` and `prepare_sim`

Before, code like this would not update, always giving the first value

```
dof_states = gym.get_actor_dof_states(
    env, self.hand_handles[i], gymapi.STATE_POS
)
```

![image](https://github.com/tylerlum/DexGraspNet/assets/26510814/a927e5f2-63d2-477f-ae96-36198f1465e3)

![image](https://github.com/tylerlum/DexGraspNet/assets/26510814/7d505652-eb83-4513-99aa-fbba24103dc8)

![image](https://github.com/tylerlum/DexGraspNet/assets/26510814/6bdaaf8d-ea2f-4feb-8ca0-849600dd78cc)

![image](https://github.com/tylerlum/DexGraspNet/assets/26510814/e7c55a71-2c98-4f16-8076-7bde7719d0ea)

Tbh, not sure if we need prepare_sim, since it might only be for the tensor API? left it in in case


