### PR TITLE
2023 11 17 dgn baseline

### DIFF
--- a/grasp_generation/eval_dgn_baseline.py
+++ b/grasp_generation/eval_dgn_baseline.py
@@ -1,0 +1,72 @@
+from tap import Tap
+import pathlib
+import subprocess
+import datetime
+
+
+class ArgumentParser(Tap):
+    meshdata_root_path: pathlib.Path = pathlib.Path("../data/meshdata")
+    nerf_meshdata_root_path: pathlib.Path = pathlib.Path("../data/nerf_meshdata")
+    plan_using_nerf: bool = False
+
+
+def print_and_run(command: str) -> None:
+    print(f"Running {command}")
+    subprocess.run(
+        command,
+        shell=True,
+        check=True,
+    )
+
+
+def main() -> None:
+    args = ArgumentParser().parse_args()
+    print("=" * 80)
+    print(f"{pathlib.Path(__file__).name} args = {args}")
+    print("=" * 80 + "\n")
+
+    assert args.meshdata_root_path.exists(), f"{args.meshdata_root_path} does not exist"
+    assert (
+        args.nerf_meshdata_root_path.exists()
+    ), f"{args.nerf_meshdata_root_path} does not exist"
+
+    output_eval_results_path = pathlib.Path(
+        "../data/eval_results"
+    ) / datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    output_eval_results_path.mkdir(parents=True, exist_ok=True)
+
+    planning_meshdata_root_path = (
+        args.nerf_meshdata_root_path
+        if args.plan_using_nerf
+        else args.meshdata_root_path
+    )
+    eval_meshdata_root_path = args.meshdata_root_path
+
+    # Gen hand configs
+    hand_gen_command = (
+        f"python scripts/generate_hand_config_dicts.py --meshdata_root_path {planning_meshdata_root_path}"
+        + f" --output_hand_config_dicts_path {output_eval_results_path / 'hand_config_dicts'}"
+        + " --use_penetration_energy"
+    )
+    print_and_run(hand_gen_command)
+
+    # Gen grasp configs
+    grasp_gen_command = (
+        f"python scripts/generate_grasp_config_dicts.py --meshdata_root_path {planning_meshdata_root_path}"
+        + f" --input_hand_config_dicts_path {output_eval_results_path / 'hand_config_dicts'}"
+        + f" --output_grasp_config_dicts_path {output_eval_results_path / 'grasp_config_dicts'}"
+    )
+    print_and_run(grasp_gen_command)
+
+    # Eval final grasp configs.
+    eval_final_grasp_command = (
+        "python scripts/eval_all_grasp_config_dicts.py"
+        + f" --input_grasp_config_dicts_path {output_eval_results_path / 'grasp_config_dicts'}"
+        + f" --output_evaled_grasp_config_dicts_path {output_eval_results_path / 'evaled_grasp_config_dicts'}"
+        + f" --meshdata_root_path {eval_meshdata_root_path}"
+    )
+    print_and_run(eval_final_grasp_command)
+
+
+if __name__ == "__main__":
+    main()

--- a/grasp_generation/eval_dgn_baseline.py
+++ b/grasp_generation/eval_dgn_baseline.py
@@ -9,6 +9,7 @@ class ArgumentParser(Tap):
     meshdata_root_path: pathlib.Path = pathlib.Path("../data/meshdata")
     nerf_meshdata_root_path: pathlib.Path = pathlib.Path("../data/nerf_meshdata")
     plan_using_nerf: bool = False
+    eval_using_nerf: bool = False
 
 
 def print_and_run(command: str) -> None:
@@ -36,12 +37,17 @@ def main() -> None:
     ) / datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     output_eval_results_path.mkdir(parents=True, exist_ok=True)
 
+    # NOTE: Expects the scale of the nerf_meshdata to be the same as the scale of the meshdata.
     planning_meshdata_root_path = (
         args.nerf_meshdata_root_path
         if args.plan_using_nerf
         else args.meshdata_root_path
     )
-    eval_meshdata_root_path = args.meshdata_root_path
+    eval_meshdata_root_path = (
+        args.nerf_meshdata_root_path
+        if args.eval_using_nerf
+        else args.meshdata_root_path
+    )
 
     # Gen hand configs
     hand_gen_command = (

--- a/grasp_generation/eval_dgn_baseline.py
+++ b/grasp_generation/eval_dgn_baseline.py
@@ -10,6 +10,9 @@ class ArgumentParser(Tap):
     nerf_meshdata_root_path: pathlib.Path = pathlib.Path("../data/nerf_meshdata")
     plan_using_nerf: bool = False
     eval_using_nerf: bool = False
+    output_eval_results_path: pathlib.Path = pathlib.Path(
+        "../data/eval_results"
+    ) / datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
 
 def print_and_run(command: str) -> None:
@@ -32,10 +35,7 @@ def main() -> None:
         args.nerf_meshdata_root_path.exists()
     ), f"{args.nerf_meshdata_root_path} does not exist"
 
-    output_eval_results_path = pathlib.Path(
-        "../data/eval_results"
-    ) / datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    output_eval_results_path.mkdir(parents=True, exist_ok=True)
+    args.output_eval_results_path.mkdir(parents=True)
 
     # NOTE: Expects the scale of the nerf_meshdata to be the same as the scale of the meshdata.
     planning_meshdata_root_path = (
@@ -52,7 +52,7 @@ def main() -> None:
     # Gen hand configs
     hand_gen_command = (
         f"python scripts/generate_hand_config_dicts.py --meshdata_root_path {planning_meshdata_root_path}"
-        + f" --output_hand_config_dicts_path {output_eval_results_path / 'hand_config_dicts'}"
+        + f" --output_hand_config_dicts_path {args.output_eval_results_path / 'hand_config_dicts'}"
         + " --use_penetration_energy"
     )
     print_and_run(hand_gen_command)
@@ -60,39 +60,33 @@ def main() -> None:
     # Gen grasp configs
     grasp_gen_command = (
         f"python scripts/generate_grasp_config_dicts.py --meshdata_root_path {planning_meshdata_root_path}"
-        + f" --input_hand_config_dicts_path {output_eval_results_path / 'hand_config_dicts'}"
-        + f" --output_grasp_config_dicts_path {output_eval_results_path / 'grasp_config_dicts'}"
+        + f" --input_hand_config_dicts_path {args.output_eval_results_path / 'hand_config_dicts'}"
+        + f" --output_grasp_config_dicts_path {args.output_eval_results_path / 'grasp_config_dicts'}"
     )
     print_and_run(grasp_gen_command)
 
     # Eval final grasp configs.
     eval_final_grasp_command = (
         "python scripts/eval_all_grasp_config_dicts.py"
-        + f" --input_grasp_config_dicts_path {output_eval_results_path / 'grasp_config_dicts'}"
-        + f" --output_evaled_grasp_config_dicts_path {output_eval_results_path / 'evaled_grasp_config_dicts'}"
+        + f" --input_grasp_config_dicts_path {args.output_eval_results_path / 'grasp_config_dicts'}"
+        + f" --output_evaled_grasp_config_dicts_path {args.output_eval_results_path / 'evaled_grasp_config_dicts'}"
         + f" --meshdata_root_path {eval_meshdata_root_path}"
     )
     print_and_run(eval_final_grasp_command)
 
-    # Look at success rate.
+    # Look at success rate of all grasps and best k grasps.
+    BEST_K = 10
     num_successes, num_total = 0, 0
-    for filepath in (output_eval_results_path / "evaled_grasp_config_dicts").iterdir():
-        print(f"Loading grasp config dicts from: {filepath}")
+    num_successes_best_k, num_total_best_k = 0, 0
+    for filepath in (
+        args.output_eval_results_path / "evaled_grasp_config_dicts"
+    ).iterdir():
         evaled_grasp_config_dict = np.load(filepath, allow_pickle=True).item()
         passed_eval = evaled_grasp_config_dict["passed_eval"]
         assert len(passed_eval.shape) == 1
 
         num_total += passed_eval.shape[0]
         num_successes += passed_eval.sum()
-    print(f"Total success rate: {num_successes / num_total}")
-
-    BEST_K = 10
-    num_successes_best_k, num_total_best_k = 0, 0
-    for filepath in (output_eval_results_path / "evaled_grasp_config_dicts").iterdir():
-        print(f"Loading grasp config dicts from: {filepath}")
-        evaled_grasp_config_dict = np.load(filepath, allow_pickle=True).item()
-        passed_eval = evaled_grasp_config_dict["passed_eval"]
-        assert len(passed_eval.shape) == 1
 
         total_energy = evaled_grasp_config_dict["Total Energy"]
         assert total_energy.shape == passed_eval.shape
@@ -103,7 +97,12 @@ def main() -> None:
 
         num_total_best_k += passed_eval[best_k_indices].shape[0]
         num_successes_best_k += passed_eval[best_k_indices].sum()
-    print(f"Total success rate of top {BEST_K} energy: {num_successes_best_k / num_total_best_k}")
+    print(
+        f"Total success rate: num_successes / num_total = {num_successes} / {num_total} = {num_successes / num_total}"
+    )
+    print(
+        f"Total success rate of top {BEST_K} energy: num_successes_best_k / num_total_best_k = {num_successes_best_k} / {num_total_best_k} = {num_successes_best_k / num_total_best_k}"
+    )
 
 
 if __name__ == "__main__":

--- a/grasp_generation/scripts/generate_hand_config_dicts.py
+++ b/grasp_generation/scripts/generate_hand_config_dicts.py
@@ -221,6 +221,7 @@ def save_hand_config_dicts(
     unweighted_energy_matrix = unweighted_energy_matrix.reshape(
         num_objects, num_grasps_per_object, -1
     )
+    energy = energy.reshape(num_objects, num_grasps_per_object)
 
     for ii, object_code in enumerate(object_code_list):
         trans, rot, joint_angles = pose_to_hand_config(hand_pose=hand_pose[ii])
@@ -234,6 +235,7 @@ def save_hand_config_dicts(
             energy_dict[energy_name] = (
                 unweighted_energy_matrix[ii, :, k].detach().cpu().numpy()
             )
+        energy_dict["Total Energy"] = energy[ii].detach().cpu().numpy()
 
         object_code_and_scale_str = object_code_and_scale_to_str(
             object_code, object_scales[ii]

--- a/grasp_generation/visualize_objs.py
+++ b/grasp_generation/visualize_objs.py
@@ -45,9 +45,9 @@ def main() -> None:
         args.meshdata_root_path.exists()
     ), f"args.meshdata_root_path {args.meshdata_root_path} does not exist"
 
-    obj_files = [
+    obj_files = sorted([
         path / "coacd" / "decomposed.obj" for path in args.meshdata_root_path.iterdir()
-    ]
+    ])
     obj_files = obj_files[: args.max_num_objects_to_visualize]
 
     # Create subplots


### PR DESCRIPTION
Changes:
* Sort objs before visualizing in `grasp_generation/visualize_objs.py` to get consistent results
* Store total energy in `grasp_generation/scripts/generate_hand_config_dicts.py` to be used when sorting grasps by energy
* `CUDA_VISIBLE_DEVICES=0 python eval_dgn_baseline.py --meshdata_root_path ../data/2023-11-17_meshdata_mugs --nerf_meshdata_root_path ../../nerf_grasping/data/2023-11-17_01-27-23/nerf_meshdata_mugs_v3 --plan_using_nerf` to run DGN pipeline to both plan grasps and evaluate those grasps (can choose to use nerf-to-mesh meshes using `--plan_using_nerf` and/or `--eval_using_nerf` for planning and eval respectively)

TODO: mostly seems to be working but might have some issues with the grasp orientations on nerf meshes, will test for next PR