### PR TITLE
2023 11 21 sim start joint angles back

### DIFF
--- a/grasp_generation/scripts/eval_all_grasp_config_dicts.py
+++ b/grasp_generation/scripts/eval_all_grasp_config_dicts.py
@@ -33,6 +33,7 @@ class EvalAllGraspConfigDictsArgumentParser(Tap):
         "../data/evaled_grasp_config_dicts"
     )
     num_random_pose_noise_samples_per_grasp: Optional[int] = None
+    move_fingers_back_at_init: bool = False
     randomize_order_seed: Optional[int] = None
     mid_optimization_steps: List[int] = []
     use_multiprocess: bool = True
@@ -100,6 +101,7 @@ def print_and_run_command_safe(
             f"--object_code_and_scale_str {object_code_and_scale_str}",
             f"--max_grasps_per_batch {args.max_grasps_per_batch}",
             f"--num_random_pose_noise_samples_per_grasp {args.num_random_pose_noise_samples_per_grasp}" if args.num_random_pose_noise_samples_per_grasp is not None else "",
+            "--move_fingers_back_at_init" if args.move_fingers_back_at_init else "",
         ]
     )
 

--- a/grasp_generation/scripts/eval_grasp_config_dict.py
+++ b/grasp_generation/scripts/eval_grasp_config_dict.py
@@ -52,6 +52,7 @@ class EvalGraspConfigDictArgumentParser(Tap):
         "../data/evaled_grasp_config_dicts"
     )
     num_random_pose_noise_samples_per_grasp: Optional[int] = None
+    move_fingers_back_at_init: bool = False
 
     # if debug_index is received, then the debug mode is on
     debug_index: Optional[int] = None
@@ -161,7 +162,7 @@ def main(args: EvalGraspConfigDictArgumentParser):
         args=args,
         hand_pose=hand_pose,
         grasp_orientations=torch.from_numpy(grasp_orientations).float().to(device),
-    )
+    ) if args.move_fingers_back_at_init else joint_angles
 
     # Debug with single grasp
     if args.debug_index is not None:
@@ -202,7 +203,6 @@ def main(args: EvalGraspConfigDictArgumentParser):
     )
     # Run validation on all grasps
     batch_size = trans.shape[0]
-
     hand_model = HandModel(hand_model_type=args.hand_model_type, device=device)
 
     # Some final shape checking.

--- a/grasp_generation/utils/joint_angle_targets.py
+++ b/grasp_generation/utils/joint_angle_targets.py
@@ -331,6 +331,34 @@ def compute_grasp_orientations(
     return grasp_orientations
 
 
+def compute_fingertip_init_targets(
+    joint_angles_start: torch.Tensor,
+    hand_model: HandModel,
+    grasp_orientations: torch.Tensor,
+) -> torch.Tensor:
+    # Sanity check
+    batch_size = joint_angles_start.shape[0]
+    num_fingers = hand_model.num_fingers
+    assert grasp_orientations.shape == (batch_size, num_fingers, 3, 3)
+
+    # Get grasp directions
+    grasp_directions = grasp_orientations[:, :, :, 2]
+    assert grasp_directions.shape == (batch_size, num_fingers, 3)
+
+    # Get current positions
+    fingertip_mean_positions = compute_fingertip_mean_contact_positions(
+        joint_angles=joint_angles_start,
+        hand_model=hand_model,
+    )
+    assert fingertip_mean_positions.shape == (batch_size, num_fingers, 3)
+
+    DIST_MOVE_FINGER_BACKWARDS = -0.02
+    fingertip_targets = (
+        fingertip_mean_positions + grasp_directions * DIST_MOVE_FINGER_BACKWARDS
+    )
+    return fingertip_targets
+
+
 def compute_fingertip_targets(
     joint_angles_start: torch.Tensor,
     hand_model: HandModel,
@@ -430,3 +458,26 @@ def compute_optimized_joint_angle_targets_given_grasp_orientations(
         fingertip_targets=fingertip_targets,
     )
     return joint_angle_targets, debug_info
+
+
+def compute_init_joint_angles_given_grasp_orientations(
+    joint_angles_start: torch.Tensor,
+    hand_model: HandModel,
+    grasp_orientations: torch.Tensor,
+) -> Tuple[torch.Tensor, defaultdict]:
+    # Get fingertip targets
+    init_fingertip_targets = compute_fingertip_init_targets(
+        joint_angles_start=joint_angles_start,
+        hand_model=hand_model,
+        grasp_orientations=grasp_orientations,
+    )
+
+    (
+        init_joint_angles,
+        debug_info,
+    ) = compute_optimized_joint_angle_targets_given_fingertip_targets(
+        joint_angles_start=joint_angles_start,
+        hand_model=hand_model,
+        fingertip_targets=init_fingertip_targets,
+    )
+    return init_joint_angles, debug_info

--- a/grasp_generation/utils/joint_angle_targets.py
+++ b/grasp_generation/utils/joint_angle_targets.py
@@ -352,7 +352,7 @@ def compute_fingertip_init_targets(
     )
     assert fingertip_mean_positions.shape == (batch_size, num_fingers, 3)
 
-    DIST_MOVE_FINGER_BACKWARDS = -0.02
+    DIST_MOVE_FINGER_BACKWARDS = -0.01
     fingertip_targets = (
         fingertip_mean_positions + grasp_directions * DIST_MOVE_FINGER_BACKWARDS
     )


### PR DESCRIPTION
Changes:
* Add `move_fingers_back_at_init` parameter to grasp_generation/scripts/eval_all_grasp_config_dicts.py and grasp_generation/scripts/eval_grasp_config_dict.py to have option to start joint angles back first

```
CUDA_VISIBLE_DEVICES=0 python scripts/eval_grasp_config_dict.py --hand_model_type ALLEGRO_HAND --validation_type NO_GRAVITY_SHAKING --gpu 0 --meshdata_root_path ../data/2023-11-21_meshdata_rubikscube_one_object --input_grasp_config_dicts_path ../data/2023-11-21_rubikscube_one_object/grasp_config_dicts --output_evaled_grasp_config_dicts_path ../data/2023-11-21_rubikscube_one_object/evaled_grasp_config_dicts_WAIT_FIRST_multinoise_10grasps_gpu_4 --object_code_and_scale_str ddg-gd_rubik_cube_poisson_004_0_1000 --max_grasps_per_batch 5000 --num_random_pose_noise_samples_per_grasp 10 --debug_index 161 --use_gui --move_fingers_back_at_init
```
