### PR TITLE
2024 01 23 table optimization

### DIFF
--- a/grasp_generation/scripts/eval_all_grasp_config_dicts.py
+++ b/grasp_generation/scripts/eval_all_grasp_config_dicts.py
@@ -19,7 +19,7 @@ import pathlib
 
 class EvalAllGraspConfigDictsArgumentParser(Tap):
     hand_model_type: HandModelType = HandModelType.ALLEGRO_HAND
-    validation_type: ValidationType = ValidationType.NO_GRAVITY_SHAKING
+    validation_type: ValidationType = ValidationType.GRAVITY_AND_TABLE
     gpu: int = 0
     max_grasps_per_batch: int = 5000
     debug_index: Optional[int] = None

--- a/grasp_generation/scripts/eval_grasp_config_dict.py
+++ b/grasp_generation/scripts/eval_grasp_config_dict.py
@@ -327,6 +327,11 @@ def main(args: EvalGraspConfigDictArgumentParser):
     else:
         passed_penetration_threshold_array = E_pen_array < args.penetration_threshold
 
+    passed_eval = (
+        passed_simulation_array
+        * passed_penetration_threshold_array
+        * passed_new_penetration_test_array
+    )
     # TODO: Remove these prints
     DEBUG = True
     if DEBUG:
@@ -340,12 +345,8 @@ def main(args: EvalGraspConfigDictArgumentParser):
             f"passed_penetration_threshold_array = {passed_penetration_threshold_array} ({passed_penetration_threshold_array.mean() * 100:.2f}%)"
         )
         print(f"E_pen_array = {E_pen_array}")
+        print(f"passed_eval = {passed_eval}")
 
-    passed_eval = (
-        passed_simulation_array
-        * passed_penetration_threshold_array
-        * passed_new_penetration_test_array
-    )
     sim_frac = np.mean(passed_simulation_array)
     new_pen_frac = np.mean(passed_new_penetration_test_array)
     pen_frac = np.mean(passed_penetration_threshold_array)

--- a/grasp_generation/scripts/eval_grasp_config_dict.py
+++ b/grasp_generation/scripts/eval_grasp_config_dict.py
@@ -40,7 +40,8 @@ import pathlib
 
 class EvalGraspConfigDictArgumentParser(Tap):
     hand_model_type: HandModelType = HandModelType.ALLEGRO_HAND
-    validation_type: ValidationType = ValidationType.NO_GRAVITY_SHAKING
+    # validation_type: ValidationType = ValidationType.NO_GRAVITY_SHAKING
+    validation_type: ValidationType = ValidationType.GRAVITY_AND_TABLE
     gpu: int = 0
     meshdata_root_path: pathlib.Path = pathlib.Path("../data/meshdata")
     input_grasp_config_dicts_path: pathlib.Path = pathlib.Path(

--- a/grasp_generation/scripts/generate_all_grasps.py
+++ b/grasp_generation/scripts/generate_all_grasps.py
@@ -92,7 +92,6 @@ def process_data(args: ArgParser):
         + f" --mid_optimization_steps {' '.join([str(x) for x in hand_configs_mid_opt_steps])}"
     )
     print_and_run(init_eval_grasp_command)
-    breakpoint()
 
     if args.results_path is not None:
         print_and_run(sync_command)

--- a/grasp_generation/scripts/generate_all_grasps.py
+++ b/grasp_generation/scripts/generate_all_grasps.py
@@ -48,8 +48,8 @@ def process_data(args: ArgParser):
         + " --use_penetration_energy"
         # + " --rand_object_scale" # Turning off so we don't have to regen nerfs every time.
         # + " --object_scale 0.03" # For cube only to get 200cm => 6cm
-        + " --batch_size_each_object 1000 --n_objects_per_batch 5"  # For more grasps per object
-        + " --store_grasps_mid_optimization_freq 200"  # For more low-quality grasps
+        # + " --batch_size_each_object 1000 --n_objects_per_batch 5"  # For more grasps per object
+        # + " --store_grasps_mid_optimization_freq 200"  # For more low-quality grasps
     )
     if args.use_multiprocess:
         hand_gen_command += " --use_multiprocess"
@@ -92,6 +92,7 @@ def process_data(args: ArgParser):
         + f" --mid_optimization_steps {' '.join([str(x) for x in hand_configs_mid_opt_steps])}"
     )
     print_and_run(init_eval_grasp_command)
+    breakpoint()
 
     if args.results_path is not None:
         print_and_run(sync_command)

--- a/grasp_generation/scripts/generate_hand_config_dicts.py
+++ b/grasp_generation/scripts/generate_hand_config_dicts.py
@@ -53,7 +53,7 @@ class GenerateHandConfigDictsArgumentParser(Tap):
         "../data/hand_config_dicts"
     )
     rand_object_scale: bool = False
-    object_scale: Optional[float] = 0.051
+    object_scale: Optional[float] = 0.075
     min_object_scale: float = 0.05
     max_object_scale: float = 0.125
     seed: Optional[int] = None

--- a/grasp_generation/scripts/generate_hand_config_dicts.py
+++ b/grasp_generation/scripts/generate_hand_config_dicts.py
@@ -117,7 +117,7 @@ class GenerateHandConfigDictsArgumentParser(Tap):
     store_grasps_mid_optimization_freq: Optional[int] = None
     store_grasps_mid_optimization_iters: Optional[List[int]] = []
     store_grasps_mid_optimization_iters: Optional[List[int]] = [25] + [
-        # int(ff * 2500) for ff in [0.2, 0.5, 0.95]
+        # int(ff * 2500) for ff in [0.2, 0.5, 0.95]  # TODO: May add this back
     ]
 
     # Continue from previous run

--- a/grasp_generation/scripts/generate_hand_config_dicts.py
+++ b/grasp_generation/scripts/generate_hand_config_dicts.py
@@ -53,7 +53,7 @@ class GenerateHandConfigDictsArgumentParser(Tap):
         "../data/hand_config_dicts"
     )
     rand_object_scale: bool = False
-    object_scale: Optional[float] = 0.075
+    object_scale: Optional[float] = 0.051
     min_object_scale: float = 0.05
     max_object_scale: float = 0.125
     seed: Optional[int] = None
@@ -115,8 +115,9 @@ class GenerateHandConfigDictsArgumentParser(Tap):
 
     # verbose (grasps throughout)
     store_grasps_mid_optimization_freq: Optional[int] = None
+    store_grasps_mid_optimization_iters: Optional[List[int]] = []
     store_grasps_mid_optimization_iters: Optional[List[int]] = [25] + [
-        int(ff * 2500) for ff in [0.2, 0.5, 0.95]
+        # int(ff * 2500) for ff in [0.2, 0.5, 0.95]
     ]
 
     # Continue from previous run

--- a/grasp_generation/scripts/generate_hand_config_dicts.py
+++ b/grasp_generation/scripts/generate_hand_config_dicts.py
@@ -294,6 +294,7 @@ def generate(
             hand_model = HandModel(
                 hand_model_type=args.hand_model_type,
                 device=device,
+                n_surface_points=1000,  # Need this for table penetration
             )
 
         with loop_timer.add_section_timer("create object model"):
@@ -344,6 +345,7 @@ def generate(
                 "Joint Limits Violation": args.w_joints,
                 "Finger Finger Distance": args.w_ff,
                 "Finger Palm Distance": args.w_fp,
+                "Hand Table Penetration": 10.0,  # TODO: Set this
             }
             energy, unweighted_energy_matrix, weighted_energy_matrix = cal_energy(
                 hand_model,

--- a/grasp_generation/scripts/generate_hand_config_dicts.py
+++ b/grasp_generation/scripts/generate_hand_config_dicts.py
@@ -345,7 +345,7 @@ def generate(
                 "Joint Limits Violation": args.w_joints,
                 "Finger Finger Distance": args.w_ff,
                 "Finger Palm Distance": args.w_fp,
-                "Hand Table Penetration": 10.0,  # TODO: Set this
+                "Hand Table Penetration": 100.0,  # TODO: Set this
             }
             energy, unweighted_energy_matrix, weighted_energy_matrix = cal_energy(
                 hand_model,

--- a/grasp_generation/scripts/generate_hand_config_dicts.py
+++ b/grasp_generation/scripts/generate_hand_config_dicts.py
@@ -95,6 +95,7 @@ class GenerateHandConfigDictsArgumentParser(Tap):
     w_joints: float = 1.0
     w_ff: float = 3.0
     w_fp: float = 0.0
+    w_tpen: float = 100.0  # TODO: Tune
     use_penetration_energy: bool = False
     penetration_iters_frac: float = (
         0.0  # Fraction of iterations to perform penetration energy calculation
@@ -346,7 +347,7 @@ def generate(
                 "Joint Limits Violation": args.w_joints,
                 "Finger Finger Distance": args.w_ff,
                 "Finger Palm Distance": args.w_fp,
-                "Hand Table Penetration": 100.0,  # TODO: Set this
+                "Hand Table Penetration": args.w_tpen,
             }
             energy, unweighted_energy_matrix, weighted_energy_matrix = cal_energy(
                 hand_model,

--- a/grasp_generation/utils/isaac_validator.py
+++ b/grasp_generation/utils/isaac_validator.py
@@ -1081,10 +1081,8 @@ class IsaacValidator:
                 [0.0, 0.0, 0.0],
             ]
         elif self.validation_type == ValidationType.GRAVITY_AND_TABLE:
-            Y_LIFT = 0.5
+            Y_LIFT = 0.2
             directions_sequence = [
-                [0.0, -Y_LIFT, 0.0],
-                [0.0, -Y_LIFT, 0.0],
                 [0.0, 0.0, 0.0],
                 [0.0, 0.0, 0.0],
                 [0.0, 0.0, 0.0],

--- a/grasp_generation/utils/isaac_validator.py
+++ b/grasp_generation/utils/isaac_validator.py
@@ -805,22 +805,6 @@ class IsaacValidator:
         hand_not_penetrate_list = [True for _ in range(len(self.envs))]
 
         while sim_step_idx < self.num_sim_steps:
-            print(f"sim_step_idx = {sim_step_idx}")
-            print(f"self.init_qpos_list = {self.init_qpos_list}")
-            print(f"self._get_joint_dof_pos_list() = {self._get_joint_dof_pos_list()}")
-            obj_pose = self._get_object_pose(env=self.envs[0], obj_handle=self.obj_handles[0])
-            print(f"obj_pose = {obj_pose.p.x}, {obj_pose.p.y}, {obj_pose.p.z}, {obj_pose.r.x}, {obj_pose.r.y}, {obj_pose.r.z}, {obj_pose.r.w}")
-            hand_pose = self._get_palm_pose(env=self.envs[0], hand_handle=self.hand_handles[0], hand_link_idx_to_name=self.hand_link_idx_to_name_dicts[0])
-            print(f"hand_pose = {hand_pose.p.x}, {hand_pose.p.y}, {hand_pose.p.z}, {hand_pose.r.x}, {hand_pose.r.y}, {hand_pose.r.z}, {hand_pose.r.w}")
-            desired_hand_pose = self.desired_hand_poses_object_frame[0]
-            print(f"desired_hand_pose = {desired_hand_pose.p.x}, {desired_hand_pose.p.y}, {desired_hand_pose.p.z}, {desired_hand_pose.r.x}, {desired_hand_pose.r.y}, {desired_hand_pose.r.z}, {desired_hand_pose.r.w}")
-            print(f"self._get_virtual_joint_dof_pos_list() = {self._get_virtual_joint_dof_pos_list()}")
-            obj_pose_tensor = self.root_state_tensor[self._get_actor_indices(envs=self.envs, actors=self.obj_handles), :7]
-            print(f"obj_pose_tensor = {obj_pose_tensor}")
-            hand_pose_tensor = self.root_state_tensor[self._get_actor_indices(envs=self.envs, actors=self.hand_handles), :7]
-            print(f"hand_pose_tensor = {hand_pose_tensor}")
-            print()
-
             # Phase 1: Do nothing, hand far away
             #   * For NO_GRAVITY_SHAKING: object should stay in place
             #   * For GRAVITY_AND_TABLE: object should fall to table and settle

--- a/grasp_generation/utils/isaac_validator.py
+++ b/grasp_generation/utils/isaac_validator.py
@@ -133,7 +133,7 @@ class IsaacValidator:
         mode: str = "direct",
         hand_friction: float = 0.6,
         obj_friction: float = 0.6,
-        num_sim_steps: int = 200,
+        num_sim_steps: int = 500,
         gpu: int = 0,
         debug_interval: float = 0.05,
         start_with_step_mode: bool = False,
@@ -428,7 +428,7 @@ class IsaacValidator:
                 env, hand_actor_handle, joint, gymapi.DOMAIN_ACTOR
             )
             HARD_SHAKE_STIFFNESS = 20000.0
-            LIGHT_SHAKE_STIFFNESS = 200.0
+            LIGHT_SHAKE_STIFFNESS = 20000.0
             hand_props["stiffness"][joint_idx] = LIGHT_SHAKE_STIFFNESS
             hand_props["damping"][joint_idx] = 10.0
 
@@ -1084,8 +1084,9 @@ class IsaacValidator:
             Y_LIFT = 0.2
             directions_sequence = [
                 [0.0, -Y_LIFT, 0.0],
-                [0.0, -Y_LIFT, 0.0],
-                [0.0, -Y_LIFT, 0.0],
+                [0.0, -Y_LIFT*3/4, 0.0],
+                [0.0, -Y_LIFT*2/4, 0.0],
+                [0.0, -Y_LIFT*1/4, 0.0],
                 [0.0, 0.0, 0.0],
                 [0.0, 0.0, 0.0],
                 [0.0, 0.0, 0.0],
@@ -1102,8 +1103,14 @@ class IsaacValidator:
 
         direction_idx = int(frac_progress * len(directions_sequence))
         direction = directions_sequence[direction_idx]
-        scale = frac_progress * len(directions_sequence) - direction_idx
-        direction_with_scale = np.array(direction) * scale
+        if direction_idx == 0:
+            prev_direction = direction
+        else:
+            prev_direction = directions_sequence[direction_idx - 1]
+        alpha = frac_progress * len(directions_sequence) - direction_idx
+        direction_with_scale = np.array(direction) * alpha + np.array(
+            prev_direction
+        ) * (1 - alpha)
 
         # direction in global frame
         # dof_pos_targets in hand frame

--- a/grasp_generation/utils/isaac_validator.py
+++ b/grasp_generation/utils/isaac_validator.py
@@ -748,8 +748,6 @@ class IsaacValidator:
                 is_hand_colliding_with_obj.append(False)
 
         assert_equals(len(is_hand_colliding_with_obj), len(self.envs))
-        if is_hand_colliding_with_obj[0]:
-            breakpoint()
         return is_hand_colliding_with_obj
 
     def _move_hands_to_objects(self) -> None:
@@ -807,6 +805,22 @@ class IsaacValidator:
         hand_not_penetrate_list = [True for _ in range(len(self.envs))]
 
         while sim_step_idx < self.num_sim_steps:
+            print(f"sim_step_idx = {sim_step_idx}")
+            print(f"self.init_qpos_list = {self.init_qpos_list}")
+            print(f"self._get_joint_dof_pos_list() = {self._get_joint_dof_pos_list()}")
+            obj_pose = self._get_object_pose(env=self.envs[0], obj_handle=self.obj_handles[0])
+            print(f"obj_pose = {obj_pose.p.x}, {obj_pose.p.y}, {obj_pose.p.z}, {obj_pose.r.x}, {obj_pose.r.y}, {obj_pose.r.z}, {obj_pose.r.w}")
+            hand_pose = self._get_palm_pose(env=self.envs[0], hand_handle=self.hand_handles[0], hand_link_idx_to_name=self.hand_link_idx_to_name_dicts[0])
+            print(f"hand_pose = {hand_pose.p.x}, {hand_pose.p.y}, {hand_pose.p.z}, {hand_pose.r.x}, {hand_pose.r.y}, {hand_pose.r.z}, {hand_pose.r.w}")
+            desired_hand_pose = self.desired_hand_poses_object_frame[0]
+            print(f"desired_hand_pose = {desired_hand_pose.p.x}, {desired_hand_pose.p.y}, {desired_hand_pose.p.z}, {desired_hand_pose.r.x}, {desired_hand_pose.r.y}, {desired_hand_pose.r.z}, {desired_hand_pose.r.w}")
+            print(f"self._get_virtual_joint_dof_pos_list() = {self._get_virtual_joint_dof_pos_list()}")
+            obj_pose_tensor = self.root_state_tensor[self._get_actor_indices(envs=self.envs, actors=self.obj_handles), :7]
+            print(f"obj_pose_tensor = {obj_pose_tensor}")
+            hand_pose_tensor = self.root_state_tensor[self._get_actor_indices(envs=self.envs, actors=self.hand_handles), :7]
+            print(f"hand_pose_tensor = {hand_pose_tensor}")
+            print()
+
             # Phase 1: Do nothing, hand far away
             #   * For NO_GRAVITY_SHAKING: object should stay in place
             #   * For GRAVITY_AND_TABLE: object should fall to table and settle

--- a/grasp_generation/utils/isaac_validator.py
+++ b/grasp_generation/utils/isaac_validator.py
@@ -133,7 +133,7 @@ class IsaacValidator:
         mode: str = "direct",
         hand_friction: float = 0.6,
         obj_friction: float = 0.6,
-        num_sim_steps: int = 500,
+        num_sim_steps: int = 500,  # TODO: Try to make this smaller to save sim time, but not so short to not lift and shake well
         gpu: int = 0,
         debug_interval: float = 0.05,
         start_with_step_mode: bool = False,
@@ -428,8 +428,8 @@ class IsaacValidator:
                 env, hand_actor_handle, joint, gymapi.DOMAIN_ACTOR
             )
             HARD_SHAKE_STIFFNESS = 20000.0
-            LIGHT_SHAKE_STIFFNESS = 20000.0
-            hand_props["stiffness"][joint_idx] = LIGHT_SHAKE_STIFFNESS
+            LIGHT_SHAKE_STIFFNESS = 200.0
+            hand_props["stiffness"][joint_idx] = HARD_SHAKE_STIFFNESS
             hand_props["damping"][joint_idx] = 10.0
 
         gym.set_actor_dof_properties(env, hand_actor_handle, hand_props)
@@ -711,8 +711,11 @@ class IsaacValidator:
                     hand_table_contacts.append(contact)
 
             if len(hand_table_contacts) > 0:
+                # TODO: Remove this debug print
                 print("HAND COLLIDES TABLE")
-                print(f"Collisions between hand and table: {[(c['body0'], c['body1']) for c in hand_table_contacts]}, {hand_link_idx_to_name}, {table_link_idx_to_name}")
+                print(
+                    f"Collisions between hand and table: {[(c['body0'], c['body1']) for c in hand_table_contacts]}, {hand_link_idx_to_name}, {table_link_idx_to_name}"
+                )
                 is_hand_colliding_with_table.append(True)
             else:
                 is_hand_colliding_with_table.append(False)
@@ -741,8 +744,11 @@ class IsaacValidator:
                     hand_obj_contacts.append(contact)
 
             if len(hand_obj_contacts) > 0:
+                # TODO: Remove this debug print
                 print("HAND COLLIDES OBJECT")
-                print(f"Collisions between hand and object: {[(c['body0'], c['body1']) for c in hand_obj_contacts]}, {hand_link_idx_to_name}, {obj_link_idx_to_name}")
+                print(
+                    f"Collisions between hand and object: {[(c['body0'], c['body1']) for c in hand_obj_contacts]}, {hand_link_idx_to_name}, {obj_link_idx_to_name}"
+                )
                 is_hand_colliding_with_obj.append(True)
             else:
                 is_hand_colliding_with_obj.append(False)
@@ -815,7 +821,9 @@ class IsaacValidator:
             # Phase 4: Shake hand
             #   * For NO_GRAVITY_SHAKING: shake from this position
             #   * For GRAVITY_AND_TABLE: lift from table first, then shake
-            PHASE_1_LAST_STEP = 50
+            PHASE_1_LAST_STEP = (
+                50  # From analysis, takes about 40 steps for ball to settle
+            )
             PHASE_2_LAST_STEP = PHASE_1_LAST_STEP + 10
             PHASE_3_LAST_STEP = PHASE_2_LAST_STEP + 15
             PHASE_4_LAST_STEP = self.num_sim_steps
@@ -1071,7 +1079,7 @@ class IsaacValidator:
         dist_to_move = 0.05
         N = 2
         if self.validation_type == ValidationType.NO_GRAVITY_SHAKING:
-            directions_sequence = [
+            targets_sequence = [
                 *([[dist_to_move, 0.0, 0.0], [-dist_to_move, 0.0, 0.0]] * N),
                 [0.0, 0.0, 0.0],
                 *([[0.0, dist_to_move, 0.0], [0.0, -dist_to_move, 0.0]] * N),
@@ -1082,11 +1090,11 @@ class IsaacValidator:
             ]
         elif self.validation_type == ValidationType.GRAVITY_AND_TABLE:
             Y_LIFT = 0.2
-            directions_sequence = [
+            targets_sequence = [
                 [0.0, -Y_LIFT, 0.0],
-                [0.0, -Y_LIFT*3/4, 0.0],
-                [0.0, -Y_LIFT*2/4, 0.0],
-                [0.0, -Y_LIFT*1/4, 0.0],
+                [0.0, -Y_LIFT * 3 / 4, 0.0],
+                [0.0, -Y_LIFT * 2 / 4, 0.0],
+                [0.0, -Y_LIFT * 1 / 4, 0.0],
                 [0.0, 0.0, 0.0],
                 [0.0, 0.0, 0.0],
                 [0.0, 0.0, 0.0],
@@ -1094,23 +1102,20 @@ class IsaacValidator:
                 *([[0.0, dist_to_move, 0.0], [0.0, -dist_to_move, 0.0]] * N),
                 *([[0.0, 0.0, dist_to_move], [0.0, 0.0, -dist_to_move]] * N),
             ]
-            directions_sequence = [
-                [direction[0], direction[1] + Y_LIFT, direction[2]]
-                for direction in directions_sequence
+            targets_sequence = [
+                [target[0], target[1] + Y_LIFT, target[2]]
+                for target in targets_sequence
             ]
         else:
             raise ValueError(f"Unknown validation_type: {self.validation_type}")
 
-        direction_idx = int(frac_progress * len(directions_sequence))
-        direction = directions_sequence[direction_idx]
-        if direction_idx == 0:
-            prev_direction = direction
-        else:
-            prev_direction = directions_sequence[direction_idx - 1]
-        alpha = frac_progress * len(directions_sequence) - direction_idx
-        direction_with_scale = np.array(direction) * alpha + np.array(
-            prev_direction
-        ) * (1 - alpha)
+        target_idx = int(frac_progress * len(targets_sequence))
+        target = targets_sequence[target_idx]
+
+        # Smooth out target so that it doesn't jump around
+        prev_target = targets_sequence[target_idx - 1] if target_idx > 0 else target
+        alpha = frac_progress * len(targets_sequence) - target_idx
+        target_smoothed = np.array(target) * alpha + np.array(prev_target) * (1 - alpha)
 
         # direction in global frame
         # virtual_joint_dof_pos_targets in hand frame
@@ -1120,7 +1125,7 @@ class IsaacValidator:
             for hand_pose in self._get_hand_poses()
         ]
         virtual_joint_dof_pos_targets = [
-            rotation_transform.inverse().transform_point(gymapi.Vec3(*direction_with_scale))
+            rotation_transform.inverse().transform_point(gymapi.Vec3(*target_smoothed))
             for rotation_transform in rotation_transforms
         ]
         virtual_joint_dof_pos_targets = [
@@ -1187,18 +1192,22 @@ class IsaacValidator:
         hand_poses = self._get_hand_poses()
 
         for env, hand_pose, dof_pos_target, dof_pos in zip(
-            self.envs, hand_poses, virtual_joint_dof_pos_targets, virtual_joint_dof_pos_list
+            self.envs,
+            hand_poses,
+            virtual_joint_dof_pos_targets,
+            virtual_joint_dof_pos_list,
         ):
+            rotation_transform = gymapi.Transform(gymapi.Vec3(0, 0, 0), hand_pose.r)
+
             # virtual_joint_dof_pos_targets in hand frame
             # direction in global frame
             # so need to perform hand frame rotation
             dof_pos_target = gymapi.Vec3(
                 dof_pos_target[0], dof_pos_target[1], dof_pos_target[2]
             )
-            rotation_transform = gymapi.Transform(gymapi.Vec3(0, 0, 0), hand_pose.r)
-            direction_target = rotation_transform.transform_point(dof_pos_target)
+            dof_pos_target_world = rotation_transform.transform_point(dof_pos_target)
             green_sphere_pose = gymapi.Transform(
-                p=hand_pose.p + direction_target,
+                p=hand_pose.p + dof_pos_target_world,
                 r=None,
             )
             gymutil.draw_lines(
@@ -1206,9 +1215,9 @@ class IsaacValidator:
             )
 
             dof_pos = gymapi.Vec3(dof_pos[0], dof_pos[1], dof_pos[2])
-            direction = rotation_transform.transform_point(dof_pos)
+            dof_pos_world = rotation_transform.transform_point(dof_pos)
             blue_sphere_pose = gymapi.Transform(
-                p=hand_pose.p + direction,
+                p=hand_pose.p + dof_pos_world,
                 r=None,
             )
             gymutil.draw_lines(
@@ -1219,7 +1228,9 @@ class IsaacValidator:
         dof_pos_list = []
         for env, hand_actor_handle in zip(self.envs, self.hand_handles):
             dof_pos = []
-            dof_states = gym.get_actor_dof_states(env, hand_actor_handle, gymapi.STATE_ALL)
+            dof_states = gym.get_actor_dof_states(
+                env, hand_actor_handle, gymapi.STATE_ALL
+            )
             for i, joint in enumerate(self.joint_names):
                 joint_idx = gym.find_actor_dof_index(
                     env, hand_actor_handle, joint, gymapi.DOMAIN_ACTOR
@@ -1232,7 +1243,9 @@ class IsaacValidator:
         dof_pos_list = []
         for env, hand_actor_handle in zip(self.envs, self.hand_handles):
             dof_pos = []
-            dof_states = gym.get_actor_dof_states(env, hand_actor_handle, gymapi.STATE_ALL)
+            dof_states = gym.get_actor_dof_states(
+                env, hand_actor_handle, gymapi.STATE_ALL
+            )
             for i, joint in enumerate(self.virtual_joint_names):
                 joint_idx = gym.find_actor_dof_index(
                     env, hand_actor_handle, joint, gymapi.DOMAIN_ACTOR

--- a/grasp_generation/utils/isaac_validator.py
+++ b/grasp_generation/utils/isaac_validator.py
@@ -711,6 +711,8 @@ class IsaacValidator:
                     hand_table_contacts.append(contact)
 
             if len(hand_table_contacts) > 0:
+                print("HAND COLLIDES TABLE")
+                print(f"Collisions between hand and table: {[(c['body0'], c['body1']) for c in hand_table_contacts]}")
                 is_hand_colliding_with_table.append(True)
             else:
                 is_hand_colliding_with_table.append(False)
@@ -739,6 +741,8 @@ class IsaacValidator:
                     hand_obj_contacts.append(contact)
 
             if len(hand_obj_contacts) > 0:
+                print("HAND COLLIDES OBJECT")
+                print(f"Collisions between hand and object: {[(c['body0'], c['body1']) for c in hand_obj_contacts]}, {hand_link_idx_to_name}, {obj_link_idx_to_name}")
                 is_hand_colliding_with_obj.append(True)
             else:
                 is_hand_colliding_with_obj.append(False)

--- a/grasp_generation/utils/isaac_validator.py
+++ b/grasp_generation/utils/isaac_validator.py
@@ -133,7 +133,7 @@ class IsaacValidator:
         mode: str = "direct",
         hand_friction: float = 0.6,
         obj_friction: float = 0.6,
-        num_sim_steps: int = 120,
+        num_sim_steps: int = 200,
         gpu: int = 0,
         debug_interval: float = 0.05,
         start_with_step_mode: bool = False,
@@ -712,7 +712,7 @@ class IsaacValidator:
 
             if len(hand_table_contacts) > 0:
                 print("HAND COLLIDES TABLE")
-                print(f"Collisions between hand and table: {[(c['body0'], c['body1']) for c in hand_table_contacts]}")
+                print(f"Collisions between hand and table: {[(c['body0'], c['body1']) for c in hand_table_contacts]}, {hand_link_idx_to_name}, {table_link_idx_to_name}")
                 is_hand_colliding_with_table.append(True)
             else:
                 is_hand_colliding_with_table.append(False)
@@ -815,7 +815,7 @@ class IsaacValidator:
             # Phase 4: Shake hand
             #   * For NO_GRAVITY_SHAKING: shake from this position
             #   * For GRAVITY_AND_TABLE: lift from table first, then shake
-            PHASE_1_LAST_STEP = 30
+            PHASE_1_LAST_STEP = 50
             PHASE_2_LAST_STEP = PHASE_1_LAST_STEP + 10
             PHASE_3_LAST_STEP = PHASE_2_LAST_STEP + 15
             PHASE_4_LAST_STEP = self.num_sim_steps

--- a/grasp_generation/utils/joint_angle_targets.py
+++ b/grasp_generation/utils/joint_angle_targets.py
@@ -382,7 +382,7 @@ def compute_fingertip_targets(
     assert fingertip_mean_positions.shape == (batch_size, num_fingers, 3)
 
     # NOTE: Important parameter to vary
-    DIST_MOVE_FINGER = 0.03
+    DIST_MOVE_FINGER = 0.05
     fingertip_targets = fingertip_mean_positions + grasp_directions * DIST_MOVE_FINGER
     return fingertip_targets
 

--- a/grasp_generation/utils/object_model.py
+++ b/grasp_generation/utils/object_model.py
@@ -11,7 +11,7 @@ import torch
 import pytorch3d.structures
 import pytorch3d.ops
 import numpy as np
-from typing import Optional
+from typing import Optional, Tuple
 
 from torchsdf import index_vertices_by_faces, compute_sdf
 
@@ -187,7 +187,7 @@ class ObjectModel:
         return distance, normals
 
     def get_plotly_data(
-        self, i, color="lightgreen", opacity=0.5, pose=None, with_surface_points=False
+        self, i, color="lightgreen", opacity=0.5, pose=None, with_surface_points=False, with_table=False
     ):
         """
         Get visualization data for plotly.graph_objects
@@ -254,10 +254,29 @@ class ObjectModel:
                     name=f"object surface points: {model_code}",
                 )
             )
+        if with_table:
+            table_mesh = self.get_hacky_table_mesh(i, scaled=True)
+            table_vertices = table_mesh.vertices
+            if pose is not None:
+                pose = np.array(pose, dtype=np.float32)
+                table_vertices = table_vertices @ pose[:3, :3].T + pose[:3, 3]
+            data.append(
+                go.Mesh3d(
+                    x=table_vertices[:, 0],
+                    y=table_vertices[:, 1],
+                    z=table_vertices[:, 2],
+                    i=table_mesh.faces[:, 0],
+                    j=table_mesh.faces[:, 1],
+                    k=table_mesh.faces[:, 2],
+                    color=color,
+                    opacity=opacity,
+                    name="table",
+                )
+            )
 
         return data
 
-    def get_bounds(self, scaled: bool = False) -> torch.Tensor:
+    def get_bounds(self, scaled: bool = True) -> torch.Tensor:
         """
         Get bounds of object meshes
 
@@ -271,20 +290,95 @@ class ObjectModel:
         bounds: (n_objects * batch_size_each, 2, 3) torch.Tensor
             bounds of object meshes
         """
+        n_objects = len(self.object_mesh_list)
         bounds = []
-        for i in range(len(self.object_mesh_list)):
+        for i in range(n_objects):
             mesh = self.object_mesh_list[i]
             bounds.append(
                 torch.from_numpy(mesh.bounds).float().to(self.device)
             )
         bounds = torch.stack(bounds)
-        assert bounds.shape == (len(self.object_mesh_list), 2, 3)
+        assert bounds.shape == (n_objects, 2, 3)
         bounds = bounds.unsqueeze(1).expand(-1, self.batch_size_each, -1, -1).reshape(-1, 2, 3)
-        assert bounds.shape == (len(self.object_mesh_list) * self.batch_size_each, 2, 3)
+        assert bounds.shape == (n_objects * self.batch_size_each, 2, 3)
 
         if scaled:
             scale = self.object_scale_tensor.reshape(-1, 1, 1)
-            assert scale.shape == (len(self.object_mesh_list) * self.batch_size_each, 1, 1)
+            assert scale.shape == (n_objects * self.batch_size_each, 1, 1)
             bounds = bounds * scale
 
         return bounds
+
+    def get_hacky_table(self, scaled: bool = True) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Hacky way to get "table" position and normal (i.e. min object y)
+
+        Args:
+            scaled (bool, optional): whether to return scaled table position. Defaults to True.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor, torch.Tensor]: table position and normal and parallel
+        """
+        n_objects = len(self.object_mesh_list)
+
+        full_batch_size = n_objects * self.batch_size_each
+        object_bounds = self.get_bounds(scaled=scaled)
+        assert object_bounds.shape == (full_batch_size, 2, 3)
+
+        min_object_y = object_bounds[:, 0, 1]
+
+        Y_OFFSET = 0.025
+        table_y = min_object_y + Y_OFFSET
+        assert table_y.shape == (full_batch_size,)
+
+        table_pos = torch.zeros(
+            [full_batch_size, 3], dtype=torch.float, device=self.device
+        )
+        table_pos[:, 1] = table_y
+
+        table_normal = (
+            torch.tensor([0, 1, 0], dtype=torch.float, device=self.device)
+            .reshape(1, 3)
+            .expand(full_batch_size, -1)
+        )
+        table_parallel = (
+            torch.tensor([1, 0, 0], dtype=torch.float, device=self.device)
+            .reshape(1, 3)
+            .expand(full_batch_size, -1)
+        )
+        assert table_pos.shape == table_normal.shape == table_parallel.shape == (full_batch_size, 3)
+
+        return table_pos, table_normal, table_parallel
+
+    def get_hacky_table_mesh(self, idx: int, scaled: bool = True) -> tm.Trimesh:
+        table_pos, table_normal, table_parallel = self.get_hacky_table(scaled=scaled)
+        table_pos, table_normal, table_parallel = (
+            table_pos[idx].detach().cpu().numpy(),
+            table_normal[idx].detach().cpu().numpy(),
+            table_parallel[idx].detach().cpu().numpy(),
+        )
+        assert table_pos.shape == table_normal.shape == (3,)
+
+        bounds = self.get_bounds(scaled=True)
+        bounds = bounds[idx].detach().cpu().numpy()
+        assert bounds.shape == (2, 3)
+        SCALE_FACTOR = 2
+        W, H = bounds[1, 0] - bounds[0, 0], bounds[1, 2] - bounds[0, 2]
+        W, H = SCALE_FACTOR * W, SCALE_FACTOR * H
+
+        table_parallel_2 = np.cross(table_normal, table_parallel)
+        corner1 = table_pos + W / 2 * table_parallel + H / 2 * table_parallel_2
+        corner2 = table_pos + W / 2 * table_parallel - H / 2 * table_parallel_2
+        corner3 = table_pos - W / 2 * table_parallel + H / 2 * table_parallel_2
+        corner4 = table_pos - W / 2 * table_parallel - H / 2 * table_parallel_2
+
+        x = np.array([corner1[0], corner2[0], corner3[0], corner4[0]])
+        y = np.array([corner1[1], corner2[1], corner3[1], corner4[1]])
+        z = np.array([corner1[2], corner2[2], corner3[2], corner4[2]])
+
+        i = [0, 0, 1]
+        j = [1, 2, 2]
+        k = [2, 3, 3]
+
+        table_mesh = tm.Trimesh(vertices=np.stack([x, y, z], axis=1), faces=np.stack([i, j, k], axis=1))
+        return table_mesh
+

--- a/grasp_generation/visualize/visualize_config_dict.py
+++ b/grasp_generation/visualize/visualize_config_dict.py
@@ -58,7 +58,7 @@ def main(args: VisualizeConfigDictArgumentParser):
     ).item()
 
     # hand model: be careful with this, as it is stateful
-    hand_model = HandModel(hand_model_type=args.hand_model_type, device=args.device)
+    hand_model = HandModel(hand_model_type=args.hand_model_type, device=args.device, n_surface_points=1000)
 
     # object model
     object_model = ObjectModel(

--- a/grasp_generation/visualize/visualize_config_dict_helper.py
+++ b/grasp_generation/visualize/visualize_config_dict_helper.py
@@ -213,7 +213,6 @@ def create_config_dict_fig(
         hand_pose_start = None
 
     # hand config dict
-    breakpoint()
     hand_config_dict_plotly_data_list = get_hand_config_dict_plotly_data_list(
         hand_model=hand_model,
         hand_pose=hand_pose,

--- a/grasp_generation/visualize/visualize_config_dict_helper.py
+++ b/grasp_generation/visualize/visualize_config_dict_helper.py
@@ -203,7 +203,7 @@ def create_config_dict_fig(
     )
 
     # hand pose start
-    if "qpos_start" in config_dict and not skip_visualize_qpos_start:
+    if "joint_angles_start" in config_dict and not skip_visualize_qpos_start:
         hand_pose_start = hand_config_to_pose(
             trans=config_dict["trans_start"],
             rot=config_dict["rot_start"],
@@ -213,6 +213,7 @@ def create_config_dict_fig(
         hand_pose_start = None
 
     # hand config dict
+    breakpoint()
     hand_config_dict_plotly_data_list = get_hand_config_dict_plotly_data_list(
         hand_model=hand_model,
         hand_pose=hand_pose,

--- a/grasp_generation/visualize/visualize_config_dict_helper.py
+++ b/grasp_generation/visualize/visualize_config_dict_helper.py
@@ -188,7 +188,7 @@ def create_config_dict_fig(
     concise_title: bool = False,
 ) -> go.Figure:
     object_plotly = object_model.get_plotly_data(
-        i=0, color="lightgreen", opacity=0.5, with_surface_points=True
+        i=0, color="lightgreen", opacity=0.5, with_surface_points=True, with_table=True
     )
 
     # hand pose


### PR DESCRIPTION
Changes:
* Add table penetration energy for generate_hand_config_dict.py: Gets the min y of the object, adds some buffer into the object (so don't get close to table), then add energy only if any surface points on the hand are under the plane
* Add visualization utils for table, including making a table mesh
* Adjust so fingers close in further
* Visualize both dof pos and dof pos target of virtual joints
* Smooth out the dof pos targets of virtual joints to vary smoothly
* Lift less high
* Change to GRAVITY_AND_TABLE by default
* Print passed_eval when debugging
* Add surface points to hand for computing table pen energy
* Fix small bug in vis utils

TODO: Look into potential bug where vis and sim don't look identical
TODO: Tune stiffness of joints and virtual joints to not allow hand to drift, but not shake too hard